### PR TITLE
feat!: refactor AI prompts to system/user architecture with stream se…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,18 @@ This project automatically scans a directory for videos, extracts their metadata
 
 ## 🧩 Features
 
-- 🎞 Scan directories for video files
-- 🧠 Use AI to generate ffmpeg compression commands
-- ⚙️ ffmpeg optimization pipeline
-- 📊 SQLite database to store video data
-- 🌐 React dashboard for approvals
+- 🎞 Scan directories for video files (`.mp4`, `.mkv`, `.avi`, `.mov`)
+- 🧠 AI-powered ffmpeg command generation using OpenAI (system + user prompt architecture)
+- ⚙️ ffmpeg optimization pipeline with progress tracking and smart abort
+- 📊 SQLite database with WAL mode and concurrent worker support
+- 🌐 React dashboard for approvals, stream selection, and monitoring
+- 🎧 Per-video audio/subtitle stream selection before optimization
+- 🔁 Automatic retry with re-optimized commands when output is too large
+- 🤖 Optional auto-confirm and auto-accept modes
 - 🐳 Fully containerized using Docker Compose
 - 🖥️ Virtual display (Xvfb) for headless video processing
 - 🔄 CI/CD with GitHub Actions and Docker Hub publishing
+- 🔧 Parallel processing workers (configurable)
 
 ---
 
@@ -23,6 +27,9 @@ This project automatically scans a directory for videos, extracts their metadata
 /video-input/              => Input videos directory
 /video-output/             => Optimized output videos
 /data/video_db.sqlite      => SQLite database
+/data/system_prompt.txt    => (Optional) AI system prompt override
+/data/user_prompt.txt      => (Optional) AI user prompt override
+/data/retry_prompt.txt     => (Optional) AI retry prompt override
 
 📦 Project Root
 ├── app/
@@ -34,17 +41,17 @@ This project automatically scans a directory for videos, extracts their metadata
 │   │   └── utils.py          => Logging utilities
 │   ├── workers/
 │   │   ├── scanner.py        => Scans videos directory
-│   │   ├── prepare.py        => Calls AI API
-│   │   ├── processor.py      => Runs ffmpeg
-│   │   ├── approver.py       => Auto approve if set in ENV
+│   │   ├── prepare.py        => AI command generation (system + user prompts)
+│   │   ├── processor.py      => Runs ffmpeg with progress tracking
+│   │   ├── approver.py       => Auto confirm/accept if enabled
 │   │   └── mover.py          => Handles file replacement
 │   ├── frontend/             => React + Vite UI
 │   └── nginx/
 │       ├── default.conf      => Production nginx config
-│       └── dev.conf          => Development nginx config (proxies to React dev server)
+│       └── dev.conf          => Development nginx config
 ├── .github/workflows/
 │   ├── docker-publish.yml       => Build & push on main (versioned + latest)
-│   └── docker-publish-alpha.yml => Build & push on alpha branch
+│   └── docker-publish-alpha.yml => Build & push on alpha (manual trigger)
 ├── Dockerfile                => Production multi-stage build
 ├── Dockerfile.dev            => Development build (hot-reload)
 ├── docker-compose.dev.yml    => Dev compose with volume mounts
@@ -55,7 +62,70 @@ This project automatically scans a directory for videos, extracts their metadata
 
 ---
 
-## ⚙️ Environment Variables (`.env`)
+## ⚙️ Environment Variables
+
+### Required
+
+| Variable | Description |
+|---|---|
+| `OPENAI_API_KEY` | OpenAI API key for AI command generation |
+
+### Application
+
+| Variable | Default | Description |
+|---|---|---|
+| `VIDEO_DIR` | `/video-input` | Directory to scan for input videos |
+| `OUTPUT_DIR` | `/video-output` | Directory for optimized output files |
+| `DB_PATH` | `/data/video_db.sqlite` | SQLite database file path |
+| `SCAN_INTERVAL` | `30` | Seconds between directory scans |
+| `FILE_STABILITY_DELAY` | `2` | Seconds to wait for file size stability check |
+
+### AI Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `AI_MODEL` | `gpt-4o-mini` | OpenAI model to use |
+| `AI_BATCH_SIZE` | `3` | Number of videos to process per AI batch |
+| `AI_INTERVAL` | `10` | Seconds between AI processing cycles |
+
+### Processing
+
+| Variable | Default | Description |
+|---|---|---|
+| `PARALLEL_WORKERS` | `1` | Number of parallel ffmpeg workers |
+| `PROCESS_RETRY_DELAY` | `30` | Seconds to wait after a processing failure |
+| `MIN_REDUCTION_RATIO` | `0.2` | Minimum compression ratio (20%) before aborting |
+| `SIZE_STABILITY_TOLERANCE` | `0.01` | Size estimation stability tolerance (1%) |
+| `SIZE_CHECK_WINDOW` | `10` | Number of progress lines to check for size stability |
+| `MAX_CONSECUTIVE_ERRORS` | `3` | Max errors before a worker stops |
+| `SLEEP_INTERVAL` | `10` | Seconds between worker polling cycles |
+| `MAX_RETRY_DELAY` | `300` | Maximum backoff delay in seconds |
+
+### Automation
+
+| Variable | Default | Description |
+|---|---|---|
+| `AUTO_CONFIRMED` | `false` | Auto-confirm pending videos with single audio stream |
+| `AUTO_ACCEPT` | `false` | Auto-accept optimized videos |
+| `CONFIRM_BATCH_SIZE` | `10` | Batch size for auto-confirm/accept |
+| `CONFIRM_INTERVAL` | `60` | Seconds between auto-confirm/accept cycles |
+
+### File Replacement
+
+| Variable | Default | Description |
+|---|---|---|
+| `REPLACE_BATCH_SIZE` | `5` | Batch size for file replacement |
+| `REPLACE_INTERVAL` | `10` | Seconds between replacement cycles |
+
+### Database
+
+| Variable | Default | Description |
+|---|---|---|
+| `DB_TIMEOUT` | `30` | SQLite connection timeout in seconds |
+| `DB_MAX_RETRIES` | `3` | Max retries on database lock |
+| `DB_RETRY_DELAY` | `0.1` | Base delay between retries in seconds |
+
+### Example `.env`
 
 ```env
 VIDEO_DIR=/video-input
@@ -63,8 +133,10 @@ OUTPUT_DIR=/video-output
 DB_PATH=/data/video_db.sqlite
 SCAN_INTERVAL=30
 OPENAI_API_KEY=<your_api_key>
-AUTO_CONFIRMED=true/false
-AUTO_ACCEPT=true/false
+AI_MODEL=gpt-4o-mini
+AUTO_CONFIRMED=false
+AUTO_ACCEPT=false
+PARALLEL_WORKERS=2
 DB_TIMEOUT=30
 DB_MAX_RETRIES=3
 DB_RETRY_DELAY=0.1
@@ -84,7 +156,7 @@ cd ai-video-optimizer
 
 ### 2. Add Videos
 
-Place your video files (`.mp4`, `.mov`, `.avi`, etc.) in the input directory mapped to `/video-input`.
+Place your video files (`.mp4`, `.mov`, `.avi`, `.mkv`) in the input directory mapped to `/video-input`.
 
 ### 3. Using Docker Hub Image (Recommended)
 
@@ -101,8 +173,6 @@ services:
       - <path-to-config>:/data
       - <path-to-video-directory>:/video-input
       - <path-to-video-output>:/video-output
-    environment:
-      - SCAN_INTERVAL=30
     ports:
       - "<PORT>:8088"
 ```
@@ -122,8 +192,6 @@ services:
       - <path-to-config>:/data
       - <path-to-video-directory>:/video-input
       - <path-to-video-output>:/video-output
-    environment:
-      - SCAN_INTERVAL=30
     ports:
       - "<PORT>:8088"
 ```
@@ -140,11 +208,11 @@ docker compose -f docker-compose.dev.yml up --build
 
 This mounts source code as volumes so changes to backend, workers, and frontend are reflected immediately without rebuilding.
 
-| Service   | URL                     |
-|-----------|-------------------------|
+| Service | URL |
+|---|---|
 | App (nginx) | http://localhost:8088 |
-| Backend   | http://localhost:8000   |
-| Frontend  | http://localhost:3000   |
+| Backend (FastAPI) | http://localhost:8000 |
+| Frontend (React dev) | http://localhost:3000 |
 
 ---
 
@@ -161,41 +229,154 @@ This mounts source code as volumes so changes to backend, workers, and frontend 
 
 ## 👨‍💻 How It Works
 
-1. **Scanner Worker** — Scans `VIDEO_DIR`, extracts metadata via `ffprobe`, adds to SQLite as `pending`
-2. **React UI** — Lists all videos, user can accept/reject
-3. **AI Optimizer Worker** — Sends accepted videos to OpenAI API, saves generated `ffmpeg` command, status becomes `ready`
-4. **Processor Worker** — Executes `ffmpeg` command, stores optimized file in `OUTPUT_DIR`, marks as `optimized`
-5. **React UI** — User accepts/rejects optimized file (accept → replace original, reject → delete)
-6. **Mover Worker** — Replaces original file with optimized version
+### Workers
+
+| Worker | File | Description |
+|---|---|---|
+| Scanner | `scanner.py` | Scans `VIDEO_DIR` recursively, extracts metadata via `ffprobe`, detects audio/subtitle streams, inserts into SQLite as `pending` |
+| Approver | `approver.py` | Auto-confirms single-audio pending videos and auto-accepts optimized videos (when `AUTO_CONFIRMED`/`AUTO_ACCEPT` are enabled) |
+| Prepare | `prepare.py` | Sends confirmed videos to OpenAI with system + user prompts, saves generated `ffmpeg` command, status becomes `ready` |
+| Processor | `processor.py` | Claims ready videos atomically, executes `ffmpeg` with real-time progress tracking, smart abort if output exceeds original size or reduction ratio is too low |
+| Mover | `mover.py` | Replaces original files with optimized versions for accepted videos, cleans up skipped files |
+
+### Processing Pipeline
+
+1. **Scanner** — Discovers new video files, extracts metadata and stream info
+2. **React UI** — User reviews pending videos, selects audio/subtitle streams, confirms or rejects
+3. **Prepare (AI)** — Generates optimized `ffmpeg` command using OpenAI
+4. **Processor** — Executes `ffmpeg` with progress tracking and smart abort
+5. **React UI** — User reviews optimized result, accepts or skips
+6. **Mover** — Replaces original file with optimized version
+
+### Smart Abort
+
+The processor automatically aborts encoding when:
+- Estimated output size exceeds the original file size
+- Estimated compression ratio falls below the configured threshold (`MIN_REDUCTION_RATIO`)
+- Size estimation has stabilized (checked over `SIZE_CHECK_WINDOW` progress lines)
+
+Aborted videos are automatically re-queued as `re-confirmed` for AI to generate a more aggressive command.
 
 ---
 
 ## ✅ Video Status Flow
 
 ```text
-pending → confirmed → ready → optimized → accepted → replaced/failed
-            ↑    ↓       ↓         ↓          ↓
-         rejected   (AI)   (ffmpeg)  (User)   (Mover)
+pending → confirmed → ready → processing → optimized → accepted → replaced
+  │          │                     │            │
+  ├→ rejected (user)               │            ├→ skipped (user)
+  ├→ replaced (mark complete)      │            │
+  │                                ├→ failed    │
+  │                                │            │
+  │                          re-confirmed ──→ ready (AI retry)
+  │                          (smart abort)
 ```
+
+### Status Descriptions
+
+| Status | Description |
+|---|---|
+| `pending` | Newly scanned, awaiting user confirmation |
+| `confirmed` | User confirmed, awaiting AI command generation |
+| `ready` | AI command generated, queued for processing |
+| `processing` | ffmpeg currently running |
+| `optimized` | Processing complete, awaiting user review |
+| `accepted` | User accepted, awaiting file replacement |
+| `replaced` | Original file replaced with optimized version (complete) |
+| `rejected` | User rejected from pending |
+| `skipped` | User skipped optimized result |
+| `failed` | Processing or replacement failed |
+| `re-confirmed` | Auto re-queued after smart abort for AI retry |
+
+### UI Tab Order
+
+Pending → Queued → Processing → Optimized → Completed → Rejected → Skipped → Failed → Confirmed
 
 ---
 
-## 🧠 Sample AI Response
+## 🎧 Audio & Subtitle Stream Selection
+
+When confirming a video from the pending screen:
+
+- **Single audio, no subtitles** — Auto-confirmed immediately
+- **Multiple audio streams or subtitles present** — Stream selection dialog opens (filename shown in orange with ⚠️ indicator)
+- User selects one audio stream (required) and optionally one subtitle stream
+- Bulk confirm only processes single-audio/no-subtitle videos; multi-stream videos are skipped with a notification
+
+All non-pending tabs display the user's selected audio and subtitle streams in dedicated columns.
+
+---
+
+## 🧠 AI Prompt Customization
+
+The AI command generator uses separate **system** and **user** prompts with a retry instruction for re-optimization. All three have sensible hardcoded defaults and can be overridden by placing text files in the `/data` volume:
+
+| File | Purpose |
+|---|---|
+| `/data/system_prompt.txt` | Override the AI's role, rules, and system context |
+| `/data/user_prompt.txt` | Override the per-video task instructions |
+| `/data/retry_prompt.txt` | Override the retry optimization instructions |
+
+If the files don't exist or are empty, built-in defaults are used.
+
+### Placeholder Substitution
+
+All prompt files support placeholder substitution:
+
+| Placeholder | Replaced With | Available In |
+|---|---|---|
+| `{{FFPROBE_DATA}}` | Video ffprobe metadata (JSON) | system, user, retry |
+| `{{SYSTEM_INFO}}` | Host system info (JSON) | system, user, retry |
+| `{{SELECTED_AUDIO}}` | User-selected audio stream | system, user, retry |
+| `{{SELECTED_SUBTITLE}}` | User-selected subtitle stream | system, user, retry |
+| `{{PREVIOUS_COMMAND}}` | Previous AI command (on retry) | system, user, retry |
+| `{{RETRY_INSTRUCTION}}` | Resolved retry prompt block (on retry, empty otherwise) | system, user |
+
+### How Prompts Are Resolved
+
+```
+1. Load system_prompt.txt (or fallback) → substitute placeholders → system message
+2. Load user_prompt.txt (or fallback)   → substitute placeholders → user message
+3. On retry: load retry_prompt.txt (or fallback) → substitute {{PREVIOUS_COMMAND}}
+             → result injected into {{RETRY_INSTRUCTION}} placeholder
+```
+
+### Sample Override: `/data/user_prompt.txt`
 
 ```text
-ffmpeg -i input.mp4 -vcodec libx265 -crf 28 output.mp4
+Video metadata: {{FFPROBE_DATA}}
+Audio: {{SELECTED_AUDIO}}
+Subtitle: {{SELECTED_SUBTITLE}}
+Generate an optimized ffmpeg command using x265 with CRF 24.
+{{RETRY_INSTRUCTION}}
+```
+
+### Sample AI Response
+
+```text
+ffmpeg -y -i input.mp4 -c:v libx265 -crf 24 -map 0:v:0 -map 0:a:0 -c:a copy -sn -movflags +faststart output.mp4
 ```
 
 ---
 
-## 🗄️ Database Concurrency Handling
+## 🗄️ Database
+
+### Concurrency Handling
 
 The system uses SQLite with WAL mode and enhanced concurrency support for multiple workers:
 
-- 📝 Write-Ahead Logging (WAL) mode
+- 📝 Write-Ahead Logging (WAL) mode for concurrent reads/writes
 - 🔄 Connection pooling with configurable timeouts
 - 🔒 Thread-safe operations with automatic retry on locks
 - 🔁 Exponential backoff for retries
+- ⚡ Atomic video claiming to prevent duplicate processing
+
+### Tables
+
+| Table | Purpose |
+|---|---|
+| `videos` | Stores video metadata, status, AI commands, stream selections, and optimization results |
+| `status_history` | Audit log of all status transitions with timestamps and comments |
 
 ---
 
@@ -203,10 +384,15 @@ The system uses SQLite with WAL mode and enhanced concurrency support for multip
 
 GitHub Actions workflows automatically build and push Docker images:
 
-- **main branch** → `tinkeshwar/video-optimizer-ai:latest` + auto-versioned tag (e.g., `1.0.42`)
-- **alpha branch** → `tinkeshwar/video-optimizer-ai:alpha`
+| Branch/Trigger | Image Tag | Description |
+|---|---|---|
+| Push to `main` | `latest` + auto-versioned (e.g., `1.0.42`) | Production release with auto-generated release notes |
+| Manual dispatch | `alpha` | Alpha/testing builds |
 
-Releases are auto-created on the main branch with incremented patch versions.
+Version bumping follows conventional commits:
+- `BREAKING CHANGE:` or `feat!:` → major bump
+- `feat:` → minor bump
+- Everything else → patch bump
 
 ---
 
@@ -215,7 +401,9 @@ Releases are auto-created on the main branch with incremented patch versions.
 - Multi-stage Docker build (Python base → Node frontend build → final image)
 - Xvfb virtual display included for headless video processing
 - ffmpeg, ffprobe, vainfo, and GPU tools (pciutils, rocm-smi) available in container
-- Nginx reverse proxy serves frontend and proxies `/api/` to FastAPI backend
+- Nginx reverse proxy serves frontend static files and proxies `/api/` to FastAPI backend
+- Development build includes Node.js for React dev server with hot-reload
+- Python dependencies: `fastapi`, `uvicorn`, `python-dotenv`, `openai`, `pydantic`
 
 ---
 

--- a/app/backend/db.py
+++ b/app/backend/db.py
@@ -127,6 +127,10 @@ def init_db():
                 add_column_if_not_exists("videos", "system_info", "TEXT")
                 add_column_if_not_exists("videos", "estimated_size", "INTEGER")
                 add_column_if_not_exists("videos", "ffprobe_data_new", "TEXT")
+                add_column_if_not_exists("videos", "audio_streams", "TEXT")
+                add_column_if_not_exists("videos", "subtitle_streams", "TEXT")
+                add_column_if_not_exists("videos", "selected_audio", "TEXT")
+                add_column_if_not_exists("videos", "selected_subtitle", "TEXT")
 
                 # Create indexes for better performance
                 cursor.execute("CREATE INDEX IF NOT EXISTS idx_filepath ON videos(filepath)")

--- a/app/backend/db_operations.py
+++ b/app/backend/db_operations.py
@@ -46,18 +46,18 @@ def fetch(query: str, params: Tuple = None, retries: int = None, fetch_one: bool
         finally:
             cursor.close()
 
-def insert_video(filepath: str, filename: str, metadata: str = None, codec: str = None, size: int = None, comment: str = None) -> int:
+def insert_video(filepath: str, filename: str, metadata: str = None, codec: str = None, size: int = None, audio_streams: str = None, subtitle_streams: str = None, comment: str = None) -> int:
     """
     Insert a new video record into the database and log the status as 'pending' in status_history.
     """
     query = """
-        INSERT INTO videos (filepath, filename, ffprobe_data, original_codec, original_size)
-        VALUES (?, ?, ?, ?, ?)
+        INSERT INTO videos (filepath, filename, ffprobe_data, original_codec, original_size, audio_streams, subtitle_streams)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
     """
     with transaction() as conn:
         cursor = conn.cursor()
         try:
-            cursor.execute(query, (filepath, filename, metadata, codec, size))
+            cursor.execute(query, (filepath, filename, metadata, codec, size, audio_streams, subtitle_streams))
             video_id = cursor.lastrowid
             cursor.execute(
                 "INSERT INTO status_history (video_id, status, comment, created_at) VALUES (?, 'pending', ?, CURRENT_TIMESTAMP)",
@@ -67,6 +67,27 @@ def insert_video(filepath: str, filename: str, metadata: str = None, codec: str 
         except sqlite3.Error as e:
             logger.error(f"Failed to insert video record: {e}")
             raise DatabaseError(f"Failed to insert video: {e}")
+        finally:
+            cursor.close()
+
+def update_video_stream_selection(video_id: int, selected_audio: str, selected_subtitle: str = None, comment: str = None) -> None:
+    """
+    Save user's audio/subtitle stream selection and set status to confirmed.
+    """
+    with transaction() as conn:
+        cursor = conn.cursor()
+        try:
+            cursor.execute(
+                "UPDATE videos SET selected_audio = ?, selected_subtitle = ?, status = 'confirmed', updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (selected_audio, selected_subtitle, video_id)
+            )
+            cursor.execute(
+                "INSERT INTO status_history (video_id, status, comment, created_at) VALUES (?, 'confirmed', ?, CURRENT_TIMESTAMP)",
+                (video_id, comment or 'User selected audio/subtitle streams')
+            )
+        except sqlite3.Error as e:
+            logger.error(f"Failed to update stream selection: {e}")
+            raise DatabaseError(f"Failed to update stream selection: {e}")
         finally:
             cursor.close()
 

--- a/app/backend/routes.py
+++ b/app/backend/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+from typing import Optional
 from backend.db import get_db
+from backend.db_operations import update_video_stream_selection
 
 router = APIRouter()
 
@@ -13,6 +15,10 @@ class BulkStatusUpdate(BaseModel):
 
 class CommandUpdate(BaseModel):
     ai_command: str
+
+class StreamSelection(BaseModel):
+    selected_audio: dict
+    selected_subtitle: Optional[dict] = None
 
 VALID_STATUSES = [
     "pending", "confirmed", "rejected", "ready", "processing", "optimized",
@@ -70,6 +76,20 @@ def update_video_command(video_id: int, payload: CommandUpdate):
         (video_id,)
     )
     return {"message": f"Command updated and video {video_id} queued for processing"}
+
+@router.put("/api/videos/{video_id}/streams")
+def update_video_streams(video_id: int, payload: StreamSelection):
+    import json
+    video = execute_query("SELECT id FROM videos WHERE id = ?", (video_id,), fetch_all=False)
+    if not video:
+        raise HTTPException(status_code=404, detail="Video not found")
+    update_video_stream_selection(
+        video_id,
+        selected_audio=json.dumps(payload.selected_audio),
+        selected_subtitle=json.dumps(payload.selected_subtitle) if payload.selected_subtitle else None,
+        comment='User selected audio/subtitle streams'
+    )
+    return {"message": f"Stream selection saved and video {video_id} confirmed"}
 
 @router.get("/api/videos")
 def get_all_videos(page: int = 1, limit: int = 10):

--- a/app/frontend/src/components/CommandEditDialog.jsx
+++ b/app/frontend/src/components/CommandEditDialog.jsx
@@ -35,7 +35,7 @@ const MetaRow = ({ label, value, newValue }) => (
   </Flex>
 );
 
-function CommandEditDialog({ open, filename, command, ffprobeData, ffprobeDataNew, onSave, onClose }) {
+function CommandEditDialog({ open, filename, command, ffprobeData, ffprobeDataNew, selectedAudio, selectedSubtitle, onSave, onClose }) {
   const [value, setValue] = useState('');
   const [error, setError] = useState('');
 
@@ -50,6 +50,13 @@ function CommandEditDialog({ open, filename, command, ffprobeData, ffprobeDataNe
 
   const meta = parseMeta(ffprobeData);
   const metaNew = parseMeta(ffprobeDataNew);
+
+  const parsedAudio = (() => {
+    try { return selectedAudio ? (typeof selectedAudio === 'string' ? JSON.parse(selectedAudio) : selectedAudio) : null; } catch { return null; }
+  })();
+  const parsedSubtitle = (() => {
+    try { return selectedSubtitle ? (typeof selectedSubtitle === 'string' ? JSON.parse(selectedSubtitle) : selectedSubtitle) : null; } catch { return null; }
+  })();
 
   const handleSave = () => {
     const trimmed = value.trim();
@@ -97,6 +104,22 @@ function CommandEditDialog({ open, filename, command, ffprobeData, ffprobeDataNe
             <MetaRow label="Size" value={meta.size} newValue={metaNew?.size} />
             <MetaRow label="Bitrate" value={meta.bitrate} newValue={metaNew?.bitrate} />
             <MetaRow label="Streams" value={meta.streams} newValue={metaNew?.streams} />
+          </Box>
+        )}
+
+        {(parsedAudio || parsedSubtitle !== undefined) && (
+          <Box mb="3" p="3" style={{ background: 'var(--meta-bg)', borderRadius: 8, border: '1px solid var(--meta-border)' }}>
+            <Text size="1" weight="bold" color="gray" mb="1" style={{ display: 'block' }}>🎧 Stream Selection</Text>
+            {parsedAudio && (
+              <MetaRow
+                label="Audio"
+                value={`#${parsedAudio.index} — ${parsedAudio.codec_name} · ${parsedAudio.channels}ch · ${parsedAudio.language || 'und'}`}
+              />
+            )}
+            <MetaRow
+              label="Subtitle"
+              value={parsedSubtitle ? `#${parsedSubtitle.index} — ${parsedSubtitle.codec_name} · ${parsedSubtitle.language || 'und'}` : 'None (removed)'}
+            />
           </Box>
         )}
 

--- a/app/frontend/src/components/FileList.jsx
+++ b/app/frontend/src/components/FileList.jsx
@@ -10,10 +10,10 @@ const TAB_CONFIG = [
   { value: 'ready', label: 'Queued', color: 'indigo' },
   { value: 'processing', label: 'Processing', color: 'violet' },
   { value: 'optimized', label: 'Optimized', color: 'green' },
-  { value: 'replaced', label: 'Completed', color: 'grass' },
   { value: 'rejected', label: 'Rejected', color: 'orange' },
   { value: 'skipped', label: 'Skipped', color: 'gray' },
   { value: 'failed', label: 'Failed', color: 'red' },
+  { value: 'replaced', label: 'Completed', color: 'grass' },
 ];
 
 function FileList() {

--- a/app/frontend/src/components/FileTable.jsx
+++ b/app/frontend/src/components/FileTable.jsx
@@ -1,16 +1,17 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { Flex, Button, Table, Box, Tooltip, Progress, Spinner, Text, Checkbox } from '@radix-ui/themes';
-import { CheckIcon, Cross2Icon, InfoCircledIcon, ResetIcon, TrashIcon, ChevronUpIcon, ChevronDownIcon, CodeIcon, CountdownTimerIcon, Pencil2Icon } from '@radix-ui/react-icons';
+import { CheckIcon, Cross2Icon, InfoCircledIcon, ResetIcon, TrashIcon, ChevronUpIcon, ChevronDownIcon, CodeIcon, CountdownTimerIcon, Pencil2Icon, CheckCircledIcon } from '@radix-ui/react-icons';
 import axios from 'axios';
 import Filters from './Filter';
 import ConfirmDialog from './ConfirmDialog';
 import HistoryDialog from './HistoryDialog';
 import CommandEditDialog from './CommandEditDialog';
+import StreamSelectDialog from './StreamSelectDialog';
 import { useToast } from './Toast';
-import { byteToHuman, runtimeFromProbe, compressionPercent, progressFromProbe, relativeTime } from '../helpers';
+import { byteToHuman, runtimeFromProbe, compressionPercent, progressFromProbe, relativeTime, formatStreamLabel } from '../helpers';
 
 const ACTION_CONFIG = {
-  pending: { positive: 'confirmed', negative: 'rejected', delete: true },
+  pending: { positive: 'confirmed', negative: 'rejected', complete: 'replaced', delete: true },
   confirmed: { revert: 'pending' },
   optimized: { positive: 'accepted', negative: 'skipped' },
   ready: { revert: 'pending' },
@@ -19,7 +20,7 @@ const ACTION_CONFIG = {
   failed: { delete: true },
 };
 
-const DESTRUCTIVE = new Set(['rejected', 'skipped', 'delete']);
+const DESTRUCTIVE = new Set(['rejected', 'skipped', 'delete', 'replaced']);
 
 function FileTable({ status, onAction }) {
   const toast = useToast();
@@ -39,6 +40,7 @@ function FileTable({ status, onAction }) {
   const [confirm, setConfirm] = useState(null);
   const [historyModal, setHistoryModal] = useState(null);
   const [commandModal, setCommandModal] = useState(null);
+  const [streamModal, setStreamModal] = useState(null);
   const itemsPerPage = 50;
 
   const HISTORY_TABS = new Set(['confirmed', 'ready', 'processing', 'optimized', 'replaced', 'rejected', 'skipped', 'failed']);
@@ -55,9 +57,13 @@ function FileTable({ status, onAction }) {
 
   const toCodec = useCallback((codec) => (codec === 'all' ? null : codec.toLowerCase()), []);
 
-  const fetchFiles = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+  const initialLoadDone = React.useRef(false);
+
+  const fetchFiles = useCallback(async (background = false) => {
+    if (!background) {
+      setLoading(true);
+      setError(null);
+    }
     try {
       const response = await axios.get(`/api/videos/${status}`, {
         params: {
@@ -69,25 +75,30 @@ function FileTable({ status, onAction }) {
       });
       setFiles(response.data.list);
       setTotalPages(response.data.total_pages);
-      setSelected(new Set());
+      if (!background) setSelected(new Set());
+      initialLoadDone.current = true;
     } catch (err) {
-      if (!axios.isCancel(err)) setError('Failed to fetch files.');
+      if (!axios.isCancel(err) && !background) setError('Failed to fetch files.');
     } finally {
-      setLoading(false);
+      if (!background) setLoading(false);
     }
   }, [currentPage, sizeFilter, codecFilter, fileNameSearch, filePathSearch, sortBy, sortOrder, status, toCodec]);
 
   useEffect(() => {
-    const timer = setTimeout(fetchFiles, 300);
+    initialLoadDone.current = false;
+    const timer = setTimeout(() => fetchFiles(false), 300);
     return () => clearTimeout(timer);
   }, [fetchFiles]);
 
+  const hasOpenDialog = !!(confirm || streamModal || commandModal || historyModal);
+
   useEffect(() => {
+    if (hasOpenDialog) return;
     if (['ready', 'processing', 'pending', 'confirmed', 'optimized'].includes(status)) {
-      const interval = setInterval(fetchFiles, 10000);
+      const interval = setInterval(() => fetchFiles(true), 10000);
       return () => clearInterval(interval);
     }
-  }, [status, fetchFiles]);
+  }, [status, fetchFiles, hasOpenDialog]);
 
   const handleSort = (col) => {
     if (sortBy === col) {
@@ -135,6 +146,20 @@ function FileTable({ status, onAction }) {
   };
 
   const confirmAction = (id, action) => {
+    if (action === 'confirmed' && status === 'pending') {
+      const file = files.find(f => f.id === id);
+      const audio = safeParseJson(file?.audio_streams);
+      const subs = safeParseJson(file?.subtitle_streams);
+      if (audio.length > 1 || subs.length > 0) {
+        setStreamModal(file);
+        return;
+      }
+      // Single audio, no subs — auto-select and confirm via streams endpoint
+      if (audio.length === 1) {
+        handleStreamConfirm(id, audio[0], null);
+        return;
+      }
+    }
     if (DESTRUCTIVE.has(action)) {
       setConfirm({ id, action, message: `Are you sure you want to ${action === 'delete' ? 'delete' : action} this video?` });
     } else {
@@ -142,7 +167,83 @@ function FileTable({ status, onAction }) {
     }
   };
 
+  const safeParseJson = (str) => {
+    try { return JSON.parse(str) || []; } catch { return []; }
+  };
+
+  const safeParseObj = (str) => {
+    try { return typeof str === 'string' ? JSON.parse(str) : str; } catch { return null; }
+  };
+
+  const formatAudioDisplay = (file) => {
+    if (status === 'pending') {
+      const streams = safeParseJson(file.audio_streams);
+      if (!streams.length) return 'NA';
+      return streams.map(s => formatStreamLabel(s)).join(', ');
+    }
+    const sel = safeParseObj(file.selected_audio);
+    return sel ? formatStreamLabel(sel) : 'NA';
+  };
+
+  const formatSubtitleDisplay = (file) => {
+    if (status === 'pending') {
+      const streams = safeParseJson(file.subtitle_streams);
+      if (!streams.length) return 'None';
+      return streams.map(s => formatStreamLabel(s)).join(', ');
+    }
+    const sel = safeParseObj(file.selected_subtitle);
+    return sel ? formatStreamLabel(sel) : 'None';
+  };
+
+  const needsManualStream = (file) => {
+    if (status !== 'pending') return false;
+    const audio = safeParseJson(file.audio_streams);
+    const subs = safeParseJson(file.subtitle_streams);
+    return audio.length > 1 || subs.length > 0;
+  };
+
+  const handleStreamConfirm = async (id, audioObj, subObj) => {
+    try {
+      await axios.put(`/api/videos/${id}/streams`, {
+        selected_audio: audioObj,
+        selected_subtitle: subObj || null,
+      });
+      toast('Stream selection saved & confirmed', 'success');
+      setStreamModal(null);
+      fetchFiles();
+      onAction?.();
+    } catch (err) {
+      toast(err.response?.data?.detail || 'Failed to save stream selection', 'error');
+    }
+  };
+
   const confirmBulk = (action) => {
+    if (action === 'confirmed' && status === 'pending') {
+      // Bulk confirm: only single-audio, no-subtitle videos
+      const ids = [...selected];
+      const eligible = files.filter(f => {
+        if (!ids.includes(f.id)) return false;
+        const audio = safeParseJson(f.audio_streams);
+        const subs = safeParseJson(f.subtitle_streams);
+        return audio.length === 1 && subs.length === 0;
+      });
+      const skipped = ids.length - eligible.length;
+      if (eligible.length > 0) {
+        Promise.all(eligible.map(f => {
+          const audio = safeParseJson(f.audio_streams);
+          return axios.put(`/api/videos/${f.id}/streams`, {
+            selected_audio: audio[0], selected_subtitle: null,
+          });
+        })).then(() => {
+          toast(`Confirmed ${eligible.length} video(s)${skipped ? `, skipped ${skipped} (multi-audio/subtitles)` : ''}`, 'success');
+          fetchFiles();
+          onAction?.();
+        }).catch(() => toast('Bulk confirm failed', 'error'));
+      } else {
+        toast(`All ${skipped} selected video(s) require manual stream selection`, 'info');
+      }
+      return;
+    }
     if (DESTRUCTIVE.has(action)) {
       setConfirm({ bulk: true, action, message: `Are you sure you want to ${action} ${selected.size} video(s)?` });
     } else {
@@ -170,6 +271,9 @@ function FileTable({ status, onAction }) {
     if (!history) return 0;
     return history.filter((h) => ['confirmed', 're-confirmed'].includes(h.status)).length;
   };
+
+  const streamModalAudio = useMemo(() => safeParseJson(streamModal?.audio_streams), [streamModal]);
+  const streamModalSubs = useMemo(() => safeParseJson(streamModal?.subtitle_streams), [streamModal]);
 
   const config = ACTION_CONFIG[status];
 
@@ -207,6 +311,7 @@ function FileTable({ status, onAction }) {
             {config?.positive && <Button size="1" color="green" onClick={() => confirmBulk(config.positive)}><CheckIcon /> {config.positive}</Button>}
             {config?.negative && <Button size="1" color="yellow" onClick={() => confirmBulk(config.negative)}><Cross2Icon /> {config.negative}</Button>}
             {config?.revert && <Button size="1" color="blue" onClick={() => confirmBulk(config.revert)}><ResetIcon /> Revert</Button>}
+            {config?.complete && <Button size="1" color="grass" onClick={() => confirmBulk(config.complete)}><CheckCircledIcon /> Complete</Button>}
             {config?.delete && <Button size="1" color="red" onClick={() => confirmBulk('delete')}><TrashIcon /> Delete</Button>}
           </Flex>
         )}
@@ -232,6 +337,8 @@ function FileTable({ status, onAction }) {
                 <Flex align="center" gap="1">Codec <SortIcon col="original_codec" /></Flex>
               </Table.ColumnHeaderCell>
               <Table.ColumnHeaderCell>Runtime</Table.ColumnHeaderCell>
+              {status !== 'pending' && <Table.ColumnHeaderCell>Audio</Table.ColumnHeaderCell>}
+              {status !== 'pending' && <Table.ColumnHeaderCell>Subtitle</Table.ColumnHeaderCell>}
               {status === 'optimized' && <Table.ColumnHeaderCell>Compressed</Table.ColumnHeaderCell>}
               {(status === 'optimized' || status === 'failed') && <Table.ColumnHeaderCell>Attempts</Table.ColumnHeaderCell>}
               <Table.ColumnHeaderCell onClick={() => handleSort('original_size')} style={{ cursor: 'pointer' }}>
@@ -255,7 +362,8 @@ function FileTable({ status, onAction }) {
                   )}
                   <Table.Cell>
                     <Flex align="center" gap="1">
-                      {file.filename}
+                      <Text color={needsManualStream(file) ? 'orange' : undefined}>{file.filename}</Text>
+                      {needsManualStream(file) && <Tooltip content="Requires manual stream selection"><Text size="1">⚠️</Text></Tooltip>}
                       <Tooltip content={file.filepath}><InfoCircledIcon /></Tooltip>
                       {(file.ai_command || file.ffprobe_data) && ['ready', 'processing', 'optimized', 'replaced', 'failed', 'confirmed', 'skipped'].includes(status) && (
                         <Tooltip content="View AI command">
@@ -271,6 +379,8 @@ function FileTable({ status, onAction }) {
                     {file.new_codec && ` → ${file.new_codec}`}
                   </Table.Cell>
                   <Table.Cell>{file.ffprobe_data ? runtimeFromProbe(file.ffprobe_data) : 'NA'}</Table.Cell>
+                  {status !== 'pending' && <Table.Cell><Text size="1">{formatAudioDisplay(file)}</Text></Table.Cell>}
+                  {status !== 'pending' && <Table.Cell><Text size="1">{formatSubtitleDisplay(file)}</Text></Table.Cell>}
                   {status === 'optimized' && <Table.Cell>{compressionPercent(file.original_size, file.optimized_size)}</Table.Cell>}
                   {(status === 'optimized' || status === 'failed') && <Table.Cell>{countAttempts(file?.history)}</Table.Cell>}
                   <Table.Cell>
@@ -309,6 +419,11 @@ function FileTable({ status, onAction }) {
                         )}
                         {config?.revert && (
                           <Button size="1" color="blue" onClick={() => handleAction(file.id, config.revert)}><ResetIcon /></Button>
+                        )}
+                        {config?.complete && (
+                          <Tooltip content="Mark complete">
+                            <Button size="1" color="grass" onClick={() => confirmAction(file.id, config.complete)}><CheckCircledIcon /></Button>
+                          </Tooltip>
                         )}
                         {config?.delete && (
                           <Button size="1" color="red" onClick={() => confirmAction(file.id, 'delete')}><TrashIcon /></Button>
@@ -375,6 +490,8 @@ function FileTable({ status, onAction }) {
         command={commandModal?.ai_command}
         ffprobeData={commandModal?.ffprobe_data}
         ffprobeDataNew={commandModal?.ffprobe_data_new}
+        selectedAudio={commandModal?.selected_audio}
+        selectedSubtitle={commandModal?.selected_subtitle}
         onClose={() => setCommandModal(null)}
         onSave={async (cmd) => {
           try {
@@ -405,6 +522,15 @@ function FileTable({ status, onAction }) {
           else handleAction(confirm.id, confirm.action);
           setConfirm(null);
         }}
+      />
+
+      <StreamSelectDialog
+        open={!!streamModal}
+        filename={streamModal?.filename}
+        audioStreams={streamModalAudio}
+        subtitleStreams={streamModalSubs}
+        onClose={() => setStreamModal(null)}
+        onConfirm={(audioObj, subObj) => handleStreamConfirm(streamModal.id, audioObj, subObj)}
       />
     </>
   );

--- a/app/frontend/src/components/Filter.jsx
+++ b/app/frontend/src/components/Filter.jsx
@@ -21,7 +21,7 @@ const Filters = ({
       <Box>
         <Select.Root
           id="size-filter"
-          defaultValue={sizeFilter}
+          value={sizeFilter}
           onValueChange={setSizeFilter}
         >
           <Select.Trigger aria-label="Filter by file size" />
@@ -42,7 +42,7 @@ const Filters = ({
       <Box>
         <Select.Root
           id="codec-filter"
-          defaultValue={codecFilter}
+          value={codecFilter}
           onValueChange={setCodecFilter}
         >
           <Select.Trigger aria-label="Filter by codec" />

--- a/app/frontend/src/components/StreamSelectDialog.jsx
+++ b/app/frontend/src/components/StreamSelectDialog.jsx
@@ -1,0 +1,103 @@
+import React, { useState, useEffect } from 'react';
+import { Flex, Button, Text, Box } from '@radix-ui/themes';
+import { Cross2Icon } from '@radix-ui/react-icons';
+
+function StreamSelectDialog({ open, filename, audioStreams, subtitleStreams, onConfirm, onClose }) {
+  const [selectedAudio, setSelectedAudio] = useState(null);
+  const [selectedSubtitle, setSelectedSubtitle] = useState(null);
+
+  const prevOpen = React.useRef(false);
+  useEffect(() => {
+    if (open && !prevOpen.current) {
+      const audio = audioStreams || [];
+      setSelectedAudio(audio.length === 1 ? audio[0].index : null);
+      setSelectedSubtitle(null);
+    }
+    prevOpen.current = open;
+  }, [open, audioStreams]);
+
+  if (!open) return null;
+
+  const audio = audioStreams || [];
+  const subs = subtitleStreams || [];
+
+  const handleConfirm = () => {
+    const audioObj = audio.find(a => a.index === selectedAudio);
+    const subObj = subs.find(s => s.index === selectedSubtitle) || null;
+    onConfirm(audioObj, subObj);
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, zIndex: 9998,
+        background: 'var(--overlay-bg)', display: 'flex',
+        alignItems: 'center', justifyContent: 'center',
+      }}
+      onClick={onClose}
+    >
+      <Box
+        p="5"
+        style={{
+          background: 'var(--dialog-bg)', borderRadius: 12,
+          boxShadow: 'var(--dialog-shadow)',
+          width: 560, maxWidth: '90vw', maxHeight: '85vh', overflow: 'auto',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Flex justify="between" align="center" mb="3">
+          <Text size="3" weight="bold">🎧 Select Streams — {filename}</Text>
+          <Button size="1" variant="ghost" onClick={onClose}><Cross2Icon /></Button>
+        </Flex>
+
+        <Box mb="3">
+          <Text size="2" weight="bold" mb="2" style={{ display: 'block' }}>Audio Stream (required)</Text>
+          {audio.map((a) => (
+            <label key={a.index} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 0', cursor: 'pointer' }}>
+              <input
+                type="radio" name="audio" checked={selectedAudio === a.index}
+                onChange={() => setSelectedAudio(a.index)}
+              />
+              <Text size="1">
+                #{a.index} — {a.codec_name} · {a.channels}ch{a.channel_layout ? ` (${a.channel_layout})` : ''} · {a.language || 'und'}
+                {a.bit_rate ? ` · ${(Number(a.bit_rate) / 1000).toFixed(0)}kbps` : ''}
+              </Text>
+            </label>
+          ))}
+        </Box>
+
+        <Box mb="3">
+          <Text size="2" weight="bold" mb="2" style={{ display: 'block' }}>Subtitle Stream (optional)</Text>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 0', cursor: 'pointer' }}>
+            <input
+              type="radio" name="subtitle" checked={selectedSubtitle === null}
+              onChange={() => setSelectedSubtitle(null)}
+            />
+            <Text size="1" color="gray">None (remove all subtitles)</Text>
+          </label>
+          {subs.map((s) => (
+            <label key={s.index} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 0', cursor: 'pointer' }}>
+              <input
+                type="radio" name="subtitle" checked={selectedSubtitle === s.index}
+                onChange={() => setSelectedSubtitle(s.index)}
+              />
+              <Text size="1">#{s.index} — {s.codec_name} · {s.language || 'und'}</Text>
+            </label>
+          ))}
+          {subs.length === 0 && (
+            <Text size="1" color="gray" style={{ paddingLeft: 24 }}>No subtitle streams found</Text>
+          )}
+        </Box>
+
+        <Flex gap="2" mt="3" justify="end">
+          <Button size="2" variant="soft" color="gray" onClick={onClose}>Cancel</Button>
+          <Button size="2" color="green" disabled={selectedAudio === null} onClick={handleConfirm}>
+            Confirm
+          </Button>
+        </Flex>
+      </Box>
+    </div>
+  );
+}
+
+export default StreamSelectDialog;

--- a/app/frontend/src/helpers.js
+++ b/app/frontend/src/helpers.js
@@ -24,6 +24,13 @@ export const relativeTime = (dateStr) => {
   return date.toLocaleDateString();
 };
 
+export const formatStreamLabel = (stream) => {
+  if (!stream) return '';
+  const obj = typeof stream === 'string' ? JSON.parse(stream) : stream;
+  const parts = [obj.codec_name, obj.channel_layout || (obj.channels ? `${obj.channels}ch` : null), obj.language].filter(Boolean);
+  return parts.join(' · ');
+};
+
 export const compressionPercent = (original, compressed) => {
   if (!original || !compressed || original <= 0) return 'NA';
   return `${(((original - compressed) / original) * 100).toFixed(1)}%`;
@@ -32,7 +39,7 @@ export const compressionPercent = (original, compressed) => {
 export const runtimeFromProbe = (ffprobe) => {
   try {
     const data = JSON.parse(ffprobe);
-    return formatDuration(parseFloat(data.duration));
+    return formatDuration(Number.parseFloat(data['format'].duration));
   } catch {
     return 'NA';
   }
@@ -41,7 +48,7 @@ export const runtimeFromProbe = (ffprobe) => {
 export const progressFromProbe = (ffprobe, ffmpegOut) => {
   try {
     const data = JSON.parse(ffprobe);
-    const duration = parseFloat(data.duration);
+    const duration = parseFloat((data.format || data).duration);
     const timeMatch = ffmpegOut.match(/time=(\d+):(\d+):(\d+\.\d+)/);
     const speedMatch = ffmpegOut.match(/speed=([\d.]+)x/);
     const bitrateMatch = ffmpegOut.match(/bitrate=\s*([\d.]+)kbits\/s/);

--- a/app/workers/approver.py
+++ b/app/workers/approver.py
@@ -1,9 +1,11 @@
 import os
+import json
 import time
 from backend.utils import logger
 from backend.db_operations import (
     get_videos_by_status,
-    update_status_of_multiple_videos
+    update_status_of_multiple_videos,
+    update_video_stream_selection
 )
 
 BATCH_SIZE = int(os.getenv("CONFIRM_BATCH_SIZE", 10))
@@ -21,13 +23,26 @@ def confirm_pending_videos():
     if not pending_videos:
         logger.info("No pending videos to confirm.")
         return
-    
-    ids = [v["id"] for v in pending_videos]
-    
-    comment = "Auto confirmed"
 
-    update_status_of_multiple_videos(ids, 'confirmed', comment=comment)
-    logger.info(f"Confirmed {len(ids)} pending videos.")
+    confirmed = 0
+    skipped = 0
+    for v in pending_videos:
+        audio = json.loads(v.get('audio_streams') or '[]')
+        if len(audio) == 1:
+            update_video_stream_selection(
+                v['id'],
+                selected_audio=json.dumps(audio[0]),
+                selected_subtitle=None,
+                comment='Auto confirmed (single audio stream)'
+            )
+            confirmed += 1
+        else:
+            skipped += 1
+
+    if confirmed:
+        logger.info(f"Auto confirmed {confirmed} single-audio videos.")
+    if skipped:
+        logger.info(f"Skipped {skipped} multi-audio videos (require manual selection).")
 
 
 

--- a/app/workers/prepare.py
+++ b/app/workers/prepare.py
@@ -6,7 +6,7 @@ import platform
 import subprocess
 import time
 import re
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Tuple
 from backend.utils import logger
 from openai import OpenAI
 from backend.db_operations import (
@@ -19,14 +19,58 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 AI_BATCH_SIZE = int(os.getenv("AI_BATCH_SIZE", 3))
 AI_INTERVAL = int(os.getenv("AI_INTERVAL", 10))
 AI_MODEL = os.getenv("AI_MODEL", "gpt-4o-mini")
-PROMPT_FILE_PATH = "/data/prompt.txt"
+SYSTEM_PROMPT_FILE = "/data/system_prompt.txt"
+USER_PROMPT_FILE = "/data/user_prompt.txt"
+RETRY_PROMPT_FILE = "/data/retry_prompt.txt"
 
 if not OPENAI_API_KEY:
     raise ValueError("OPENAI_API_KEY environment variable is required")
 
+# ── Fallback Prompts ──
+
+FALLBACK_SYSTEM_PROMPT = """You are a video processing expert specializing in ffmpeg command generation.
+You have deep knowledge of video codecs (x264, x265, AV1), container formats,
+hardware acceleration (NVENC, VAAPI, QSV), and compression optimization.
+
+System environment:
+{{SYSTEM_INFO}}
+
+Rules:
+- Only respond with a single-line ffmpeg command starting with `ffmpeg`.
+- Do not include any explanations, markdown, code fences, or extra text.
+- Use `input.mp4` as input and `output.mp4` as output.
+- Output command must overwrite existing files.
+- Recheck the command against all user requirements before responding."""
+
+FALLBACK_USER_PROMPT = """Here is the metadata of a video file:
+{{FFPROBE_DATA}}
+
+User selected audio stream: {{SELECTED_AUDIO}}
+User selected subtitle stream: {{SELECTED_SUBTITLE}}
+
+Generate the most optimal ffmpeg command to compress this video with the following requirements:
+- Prioritize significant space savings while preserving visual quality.
+- Use the x265 codec if supported.
+- Maintain the original resolution and frame rate exactly.
+- Use hardware acceleration (e.g., NVENC, VAAPI, or QSV) only if available in the system environment, and add required tags in the command.
+- Avoid lossless mode, but keep compression visually lossless (e.g., CRF 22-28 based on content).
+- Map only the user-selected audio stream using its index (e.g., `-map 0:a:0`). Copy audio without re-encoding.
+- If a subtitle stream is selected, map it (e.g., `-map 0:s:0`). If no subtitle is selected, use `-sn` to remove all subtitles.
+- Add `-movflags +faststart` for web-streaming compatibility.
+{{RETRY_INSTRUCTION}}"""
+
+RETRY_INSTRUCTION_TEMPLATE = """
+The previous command was:
+{{PREVIOUS_COMMAND}}
+The estimated output size is too large compared to the original.
+Re-generate a more efficient command.
+Use -b:v (bitrate) and/or -maxrate/-bufsize to cap the output size more effectively if -global_quality of the last command is 30 or more.
+The new command must always be more efficient than the previous one."""
+
+# ── System Info Detection ──
+
 
 def get_system_info() -> Dict[str, str]:
-    """Retrieve system information including OS, CPU, GPU, and other hardware details."""
     info = {
         "OS": os.getenv("HOST_OS", platform.system()),
         "OS_Version": os.getenv("HOST_OS_VERSION", platform.version()),
@@ -35,24 +79,21 @@ def get_system_info() -> Dict[str, str]:
         "Total_RAM_kB": os.getenv("HOST_TOTAL_RAM", "Unknown"),
         "Python_Version": platform.python_version(),
     }
-
     gpu_info = detect_gpu()
     if gpu_info:
         info["GPU"] = gpu_info
-
     return info
 
 
 def detect_gpu() -> Optional[str]:
-    """Detect GPU information using various tools."""
     env_gpu = os.getenv("HOST_GPU_MODEL")
     if env_gpu:
         return f"Host GPU: {env_gpu}"
 
     gpu_detection_methods = [
+        (["rocm-smi", "--showproductname"], None, "AMD GPU (ROCm): {output}"),
         (["vainfo"], "VAProfile", "VAAPI available"),
-        (["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"], None, "NVIDIA GPU: {output}"),
-        (["rocm-smi", "--showproductname"], None, "AMD GPU (ROCm): {output}")
+        (["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"], None, "NVIDIA GPU: {output}")
     ]
 
     for command, keyword, message in gpu_detection_methods:
@@ -67,7 +108,6 @@ def detect_gpu() -> Optional[str]:
 
 
 def detect_gpu_via_lspci() -> Optional[str]:
-    """Detect GPU using lspci on Linux."""
     lspci_output = run_command(["lspci"])
     if not lspci_output:
         return "No discrete GPU detected via lspci"
@@ -81,22 +121,73 @@ def detect_gpu_via_lspci() -> Optional[str]:
 
 
 def run_command(command: List[str]) -> Optional[str]:
-    """Run a shell command and return its output."""
     try:
         return subprocess.check_output(command, text=True, stderr=subprocess.DEVNULL).strip()
     except (subprocess.SubprocessError, FileNotFoundError):
         return None
 
 
-def generate_ai_command(prompt: str) -> Optional[str]:
-    """Send a prompt to OpenAI and return the generated command."""
+# ── Prompt Building ──
+
+
+def load_prompt_template(filepath: str, fallback: str) -> str:
+    if os.path.exists(filepath):
+        with open(filepath, "r") as f:
+            content = f.read().strip()
+            if content:
+                logger.info(f"Loaded prompt override from {filepath}")
+                return content
+    return fallback
+
+
+def resolve_placeholders(template: str, placeholders: Dict[str, str]) -> str:
+    for key, value in placeholders.items():
+        template = template.replace(key, str(value))
+    return template
+
+
+def build_placeholders(video: Dict, system_info: Dict, previous_command: Optional[str] = None) -> Dict[str, str]:
+    retry_instruction = ""
+    if previous_command:
+        retry_template = load_prompt_template(RETRY_PROMPT_FILE, RETRY_INSTRUCTION_TEMPLATE)
+        retry_instruction = resolve_placeholders(
+            retry_template,
+            {"{{PREVIOUS_COMMAND}}": previous_command}
+        )
+
+    return {
+        "{{FFPROBE_DATA}}": json.dumps(video.get("ffprobe_data", {}), indent=2),
+        "{{SYSTEM_INFO}}": json.dumps(system_info, indent=2),
+        "{{SELECTED_AUDIO}}": video.get("selected_audio") or "Not specified",
+        "{{SELECTED_SUBTITLE}}": video.get("selected_subtitle") or "None (remove all subtitles)",
+        "{{PREVIOUS_COMMAND}}": previous_command or "",
+        "{{RETRY_INSTRUCTION}}": retry_instruction,
+    }
+
+
+def build_prompts(video: Dict, system_info: Dict, previous_command: Optional[str] = None) -> Tuple[str, str]:
+    placeholders = build_placeholders(video, system_info, previous_command)
+
+    system_template = load_prompt_template(SYSTEM_PROMPT_FILE, FALLBACK_SYSTEM_PROMPT)
+    user_template = load_prompt_template(USER_PROMPT_FILE, FALLBACK_USER_PROMPT)
+
+    system_prompt = resolve_placeholders(system_template, placeholders)
+    user_prompt = resolve_placeholders(user_template, placeholders)
+
+    return system_prompt, user_prompt
+
+
+# ── AI Interaction ──
+
+
+def generate_ai_command(system_prompt: str, user_prompt: str) -> Optional[str]:
     try:
         client = OpenAI(api_key=OPENAI_API_KEY)
         response = client.chat.completions.create(
             model=AI_MODEL,
             messages=[
-                {"role": "system", "content": "You are a video processing expert."},
-                {"role": "user", "content": prompt}
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt}
             ],
             temperature=0.3
         )
@@ -106,51 +197,17 @@ def generate_ai_command(prompt: str) -> Optional[str]:
         return None
 
 
-def create_prompt(video: Dict, system_info: Dict, previous_command: Optional[str] = None) -> str:
-    """Create a prompt for OpenAI based on video metadata and system info."""
-    base_prompt = f"""
-        Here is the metadata of a video file:
-        ffprobe data: {json.dumps(video["ffprobe_data"], indent=2)}
-        System info: {json.dumps(system_info, indent=2)}
+def extract_ffmpeg_command(text: str) -> str:
+    text = re.sub(r"^```(?:bash)?\s*", "", text.strip(), flags=re.IGNORECASE)
+    text = re.sub(r"\s*```$", "", text.strip())
+    match = re.search(r"(ffmpeg\s.+)", text, flags=re.DOTALL)
+    return match.group(1).strip() if match else text.strip()
 
-    """
 
-    if os.path.exists(PROMPT_FILE_PATH):
-        with open(PROMPT_FILE_PATH, "r") as file:
-            custom_prompt = file.read().strip()
-        base_prompt += custom_prompt
-    else:
-        base_prompt += f"""
-            Your task is to generate the most optimal ffmpeg command to compress this video with the following requirements:
-
-                - Prioritize significant space savings while preserving visual quality.
-                - Use the **x265** codec if supported.
-                - Maintain the original **resolution** and **frame rate** exactly.
-                - Use **hardware acceleration** only (e.g., NVENC, VAAPI, or QSV) if available in system_info, add required tag in command.
-                - Avoid lossless mode, but keep compression visually lossless (e.g., CRF 22-28 based on ffprobe_data).
-                - Audio should be copied without re-encoding.
-                - The result should be web-streaming friendly (i.e., add `-movflags +faststart`).
-                - Only return a single-line ffmpeg command starting with `ffmpeg`.
-                - Use `input.mp4` as input and `output.mp4` as output.
-                - In file exist in output command should overwrite the file.
-                - Do not include any other text or explanations.
-                - Recheck command against all requirements.
-        """
-
-    if previous_command:
-        base_prompt += f"""
-            Here is the last command:
-            {previous_command}
-            The estimated size is too large compared to the original size.
-            Please re-generate the command to be more efficient.
-            Use -b:v (bitrate) and/or -maxrate/-bufsize to cap the output size more effectively if -global_quality of last command is 30 or more.
-            The command should always be more efficient than the last one.
-        """
-    return base_prompt
+# ── Video Processing ──
 
 
 def process_videos(status: str, regenerate: bool = False):
-    """Process a batch of videos based on their status."""
     videos = get_videos_by_status(status, AI_BATCH_SIZE)
     if not videos:
         logger.info(f"No {status} videos to process.")
@@ -160,29 +217,21 @@ def process_videos(status: str, regenerate: bool = False):
 
     for video in videos:
         logger.info(f"Processing video: {video['filename']}")
-        prompt = create_prompt(video, system_info, video["ai_command"] if regenerate else None)
-        command = generate_ai_command(prompt)
+        previous_command = video["ai_command"] if regenerate else None
+        system_prompt, user_prompt = build_prompts(video, system_info, previous_command)
+        command = generate_ai_command(system_prompt, user_prompt)
         if command:
             command = extract_ffmpeg_command(command)
+            comment = f"AI command {'regenerated' if regenerate else 'generated'} using {AI_MODEL}"
             update_video_command_and_system_info(
-                video["id"], command, json.dumps(system_info, indent=2),
-                comment=f"AI command generated using {AI_MODEL}" if not regenerate else f"AI command regenerated using {AI_MODEL}"
+                video["id"], command, json.dumps(system_info, indent=2), comment=comment
             )
             logger.info(f"[Saved] AI command saved for video ID: {video['id']}")
         else:
             logger.warning(f"[Skipped] AI command generation failed for video ID: {video['id']}")
 
 
-def extract_ffmpeg_command(text: str) -> str:
-    """Extract the ffmpeg command from the AI response."""
-    text = re.sub(r"^```(?:bash)?\s*", "", text.strip(), flags=re.IGNORECASE)
-    text = re.sub(r"\s*```$", "", text.strip())
-    match = re.search(r"(ffmpeg\s.+)", text, flags=re.DOTALL)
-    return match.group(1).strip() if match else text.strip()
-
-
 def main():
-    """Main function to continuously process video batches."""
     logger.info("Starting AI Command Generator...")
     while True:
         try:

--- a/app/workers/scanner.py
+++ b/app/workers/scanner.py
@@ -40,9 +40,12 @@ def is_file_stable(filepath: Path) -> bool:
 def get_video_metadata_and_codec(filepath: Path) -> Optional[dict]:
     """Return both metadata and codec name for a video file."""
     cmd = [
-        "ffprobe", "-v", "quiet", "-print_format", "json",
-        "-show_format", "-show_streams", "-select_streams", "v:0",
-        "-show_entries", "stream=codec_name", str(filepath)
+        "ffprobe", "-v", "quiet", 
+        "-print_format", "json",
+        "-show_format", 
+        "-show_streams", 
+        "-show_entries", "format:stream=index,codec_type,codec_name,channel_layout,channels,bit_rate,tags",
+        str(filepath)
     ]
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
@@ -78,10 +81,30 @@ def scan_and_insert() -> None:
             if not data:
                 continue
 
-            # Extract metadata and codec
-            metadata = json.dumps(data['format'], indent=2)
-            codec = data['streams'][0]['codec_name'] if 'streams' in data and data['streams'] else 'Unknown'
+            # Extract metadata, codec, and streams
+            metadata = json.dumps(data, indent=2)
+            streams = data.get('streams', [])
+            video_stream = next((s for s in streams if s.get('codec_type') == 'video'), None)
+            codec = video_stream['codec_name'] if video_stream else 'Unknown'
             size = filepath.stat().st_size
+
+            audio_streams = json.dumps([
+                {
+                    'index': s.get('index'), 'codec_name': s.get('codec_name'),
+                    'codec_type': 'audio', 'channels': s.get('channels'),
+                    'channel_layout': s.get('channel_layout'),
+                    'bit_rate': s.get('bit_rate'),
+                    'language': (s.get('tags') or {}).get('language', 'und')
+                } for s in streams if s.get('codec_type') == 'audio'
+            ])
+
+            subtitle_streams = json.dumps([
+                {
+                    'index': s.get('index'), 'codec_name': s.get('codec_name'),
+                    'codec_type': 'subtitle',
+                    'language': (s.get('tags') or {}).get('language', 'und')
+                } for s in streams if s.get('codec_type') == 'subtitle'
+            ])
 
             # Insert video using the new db_operations module
             try:
@@ -91,6 +114,8 @@ def scan_and_insert() -> None:
                     metadata=metadata,
                     codec=codec,
                     size=size,
+                    audio_streams=audio_streams,
+                    subtitle_streams=subtitle_streams,
                     comment=f"Scanned from {filepath.parent}"
                 )
                 new_files.append(filepath)


### PR DESCRIPTION
BREAKING CHANGE: prepare.py now uses separate system/user/retry prompts instead of a single prompt. The old /data/prompt.txt file is no longer read. Users must migrate to /data/system_prompt.txt, /data/user_prompt.txt, and /data/retry_prompt.txt.

AI Prompts:
- Replace single-prompt approach with system + user + retry prompt separation
- Add hardcoded fallback defaults for all three prompts
- Add file-based overrides (/data/system_prompt.txt, /data/user_prompt.txt, /data/retry_prompt.txt)
- Add placeholder substitution ({{FFPROBE_DATA}}, {{SYSTEM_INFO}}, {{SELECTED_AUDIO}}, {{SELECTED_SUBTITLE}}, {{PREVIOUS_COMMAND}}, {{RETRY_INSTRUCTION}})
- Remove deprecated /data/prompt.txt support

UI - Pending Screen:
- Highlight filenames in orange with warning for videos requiring manual stream selection
- Add Mark Complete action to skip optimization and move directly to replaced status
- Hide audio/subtitle columns on pending tab

UI - All Screens:
- Fix flickering caused by loading spinner on background auto-reload
- Fix checkbox selections clearing on auto data reload
- Fix stream selection dialog resetting user choices on parent re-render
- Pause background auto-reload while any dialog is open
- Add audio and subtitle stream columns showing user selections
- Use controlled value instead of defaultValue on filter dropdowns
- Move Confirmed tab to last position in tab order

Docs:
- Rewrite README with complete documentation