### PR TITLE
feat: add server-side stream tier filter on pending tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,10 +300,10 @@ The scanner extracts all audio and subtitle streams from each video during scan 
 
 | Indicator | Condition | Auto-approve | Action on confirm |
 |---|---|---|---|
-| ⚪ White | Single audio, 0–1 subtitle | ✅ Yes | Auto-selects audio, removes subtitles |
-| 🟢 Green | Single audio, 2+ subtitles | ✅ Yes | Opens stream selection dialog |
-| 🟡 Yellow | Multiple audio, 0–1 subtitle | ❌ No | Opens stream selection dialog |
-| 🔴 Red | Multiple audio, 2+ subtitles | ❌ No | Opens stream selection dialog |
+| ⚪ Single Audio-Single Sub | Single audio, 0–1 subtitle | ✅ Yes | Auto-selects audio, removes subtitles |
+| 🟢 Single Audio-Multi Sub | Single audio, 2+ subtitles | ✅ Yes | Opens stream selection dialog |
+| 🟡 Multi Audio-Single Sub | Multiple audio, 0–1 subtitle | ❌ No | Opens stream selection dialog |
+| 🔴 Multi Audio-Multi Sub | Multiple audio, 2+ subtitles | ❌ No | Opens stream selection dialog |
 
 - Row background and filename text are tinted to match the tier color
 - A **Stream Tier** filter dropdown on the pending tab allows filtering by tier

--- a/app/backend/routes.py
+++ b/app/backend/routes.py
@@ -101,8 +101,27 @@ def get_all_videos(page: int = 1, limit: int = 10):
         raise HTTPException(status_code=404, detail="No videos found")
     return [dict(row) for row in rows]
 
+TIER_SQL = {
+    'white': """(
+        (SELECT COUNT(*) FROM json_each(audio_streams) WHERE json_extract(value, '$.codec_type') = 'audio') = 1
+        AND (SELECT COUNT(*) FROM json_each(subtitle_streams) WHERE json_extract(value, '$.codec_type') = 'subtitle') < 2
+    )""",
+    'green': """(
+        (SELECT COUNT(*) FROM json_each(audio_streams) WHERE json_extract(value, '$.codec_type') = 'audio') = 1
+        AND (SELECT COUNT(*) FROM json_each(subtitle_streams) WHERE json_extract(value, '$.codec_type') = 'subtitle') >= 2
+    )""",
+    'yellow': """(
+        (SELECT COUNT(*) FROM json_each(audio_streams) WHERE json_extract(value, '$.codec_type') = 'audio') > 1
+        AND (SELECT COUNT(*) FROM json_each(subtitle_streams) WHERE json_extract(value, '$.codec_type') = 'subtitle') < 2
+    )""",
+    'red': """(
+        (SELECT COUNT(*) FROM json_each(audio_streams) WHERE json_extract(value, '$.codec_type') = 'audio') > 1
+        AND (SELECT COUNT(*) FROM json_each(subtitle_streams) WHERE json_extract(value, '$.codec_type') = 'subtitle') >= 2
+    )""",
+}
+
 @router.get("/api/videos/{status}")
-def get_specific_videos(status: str, page: int = 1, limit: int = 10, codec: str = None, size: int = None, name: str = None, directory: str = None, sort_by: str = None, sort_order: str = 'asc'):
+def get_specific_videos(status: str, page: int = 1, limit: int = 10, codec: str = None, size: int = None, name: str = None, directory: str = None, sort_by: str = None, sort_order: str = 'asc', stream_tier: str = None):
     if status not in VALID_STATUSES:
         raise HTTPException(status_code=400, detail="Invalid status")
     
@@ -121,6 +140,8 @@ def get_specific_videos(status: str, page: int = 1, limit: int = 10, codec: str 
     if directory:
         filters.append("filepath LIKE ?")
         params.append(f"%{directory}%")
+    if stream_tier and stream_tier in TIER_SQL:
+        filters.append(TIER_SQL[stream_tier])
     
     where_clause = " AND ".join(filters)
     

--- a/app/frontend/src/components/FileTable.jsx
+++ b/app/frontend/src/components/FileTable.jsx
@@ -72,6 +72,7 @@ function FileTable({ status, onAction }) {
           size: toByte(sizeFilter), codec: toCodec(codecFilter),
           name: fileNameSearch, directory: filePathSearch,
           sort_by: sortBy, sort_order: sortOrder,
+          ...(status === 'pending' && streamTierFilter !== 'all' ? { stream_tier: streamTierFilter } : {}),
         },
       });
       setFiles(response.data.list);
@@ -83,7 +84,7 @@ function FileTable({ status, onAction }) {
     } finally {
       if (!background) setLoading(false);
     }
-  }, [currentPage, sizeFilter, codecFilter, fileNameSearch, filePathSearch, sortBy, sortOrder, status, toCodec]);
+  }, [currentPage, sizeFilter, codecFilter, fileNameSearch, filePathSearch, sortBy, sortOrder, status, toCodec, streamTierFilter]);
 
   useEffect(() => {
     initialLoadDone.current = false;
@@ -280,10 +281,10 @@ function FileTable({ status, onAction }) {
   };
 
   const toggleAll = () => {
-    if (selected.size === filteredFiles.length) {
+    if (selected.size === files.length) {
       setSelected(new Set());
     } else {
-      setSelected(new Set(filteredFiles.map((f) => f.id)));
+      setSelected(new Set(files.map((f) => f.id)));
     }
   };
 
@@ -291,11 +292,6 @@ function FileTable({ status, onAction }) {
     if (!history) return 0;
     return history.filter((h) => ['confirmed', 're-confirmed'].includes(h.status)).length;
   };
-
-  const filteredFiles = useMemo(() => {
-    if (status !== 'pending' || streamTierFilter === 'all') return files;
-    return files.filter(f => getStreamTier(f) === streamTierFilter);
-  }, [files, streamTierFilter, status]);
 
   const streamModalAudio = useMemo(() => safeParseJson(streamModal?.audio_streams), [streamModal]);
   const streamModalSubs = useMemo(() => safeParseJson(streamModal?.subtitle_streams), [streamModal]);
@@ -354,7 +350,7 @@ function FileTable({ status, onAction }) {
             <Table.Row>
               {hasActions && (
                 <Table.ColumnHeaderCell style={{ width: 32 }}>
-                  <Checkbox checked={selected.size === filteredFiles.length && filteredFiles.length > 0} onCheckedChange={toggleAll} />
+                  <Checkbox checked={selected.size === files.length && files.length > 0} onCheckedChange={toggleAll} />
                 </Table.ColumnHeaderCell>
               )}
               <Table.ColumnHeaderCell onClick={() => handleSort('filename')} style={{ cursor: 'pointer' }}>
@@ -379,7 +375,7 @@ function FileTable({ status, onAction }) {
             </Table.Row>
           </Table.Header>
           <Table.Body>
-            {filteredFiles.map((file, index) => (
+            {files.map((file, index) => (
               <React.Fragment key={file.id}>
                 <Table.Row style={{ backgroundColor: TIER_ROW_BG[getStreamTier(file)] || (index % 2 === 0 ? 'var(--row-alt-bg)' : 'transparent') }}>
                   {hasActions && (

--- a/app/frontend/src/components/Filter.jsx
+++ b/app/frontend/src/components/Filter.jsx
@@ -56,6 +56,25 @@ const Filters = ({
         </Select.Root>
       </Box>
 
+      {streamTierFilter !== undefined && (
+        <Box>
+          <Select.Root
+            id="stream-tier-filter"
+            value={streamTierFilter}
+            onValueChange={setStreamTierFilter}
+          >
+            <Select.Trigger aria-label="Filter by stream tier" />
+            <Select.Content>
+              <Select.Item value="all">All Tiers</Select.Item>
+              <Select.Item value="white">⚪ Single Audio-Single Sub</Select.Item>
+              <Select.Item value="green">🟢 Single Audio-Multi Sub</Select.Item>
+              <Select.Item value="yellow">🟡 Multi Audio-Single Sub</Select.Item>
+              <Select.Item value="red">🔴 Multi Audio-Multi Sub</Select.Item>
+            </Select.Content>
+          </Select.Root>
+        </Box>
+      )}
+
       <Box>
         <TextField.Root
           id="file-name-search"
@@ -81,25 +100,6 @@ const Filters = ({
           </TextField.Slot>
         </TextField.Root>
       </Box>
-
-      {streamTierFilter !== undefined && (
-        <Box>
-          <Select.Root
-            id="stream-tier-filter"
-            value={streamTierFilter}
-            onValueChange={setStreamTierFilter}
-          >
-            <Select.Trigger aria-label="Filter by stream tier" />
-            <Select.Content>
-              <Select.Item value="all">All Streams</Select.Item>
-              <Select.Item value="white">⚪ Single audio, 0-1 sub</Select.Item>
-              <Select.Item value="green">🟢 Single audio, 2+ subs</Select.Item>
-              <Select.Item value="yellow">🟡 Multi audio, 0-1 sub</Select.Item>
-              <Select.Item value="red">🔴 Multi audio, 2+ subs</Select.Item>
-            </Select.Content>
-          </Select.Root>
-        </Box>
-      )}
     </Flex>
   );
 };


### PR DESCRIPTION
- Add stream_tier query param to GET /api/videos/{status} with SQL filtering using json_each on audio_streams/subtitle_streams columns
- Add Stream Tier dropdown to filter bar (pending tab only) with labels: Single Audio-Single Sub, Single Audio-Multi Sub, Multi Audio-Single Sub, Multi Audio-Multi Sub
- Filter follows same pattern as existing size/codec filters (server-side, paginated, consistent Select component structure)
- Update README with new tier labels